### PR TITLE
Export object plugin step with necessary ant taskdefs.

### DIFF
--- a/deploy.ant.xml
+++ b/deploy.ant.xml
@@ -40,6 +40,8 @@
   domain-restart - restart the domain
   domain-unquiesce - unquiesce all the services in the domain
   
+  export-object - export an object i.e. service
+  
   host-alias-remove - remove a specific host alias
   host-alias-set - create/overwrite a host alias
   
@@ -591,6 +593,38 @@
   
   
   <!--
+      Export an object from a domain on the device.
+  -->
+  <target name="export-object" depends="-init-dir, check-access">
+    
+    <fail message="The Ant property 'domain' is required but not defined.  This is the name of a domain on the DataPower device." unless="domain"/>
+    <fail message="The Ant property 'object.class' is required but not defined.  This is the object's class." unless="object.class"/>
+    <fail message="The Ant property 'object.name' is required but not defined.  This is the name of the target object on the DataPower device." unless="object.name"/>
+    <fail message="The Ant property 'export.file' is required but not defined.  This is the filename where the backup will be written." unless="export.file"/>
+    
+    <sequential>
+      <local name="dirname"/>
+      <dirname property="dirname" file="${export.file}"/>
+      <if>
+        <not>
+          <isfileselected file="${dirname}">
+            <writable/>
+          </isfileselected>
+        </not>
+        <then>
+          <fail message="No permission to write ${export.file} into folder ${dirname}"/>
+        </then>
+      </if>
+    </sequential>
+    
+    <exportObject host="${host}" port="${port}" uid="${uid}" pwd="${pwd}" domain="${domain}" local="${export.file}" 
+      dumpinput="${dumpinput}" dumpoutput="${dumpoutput}" capturesoma="${capturesoma}" 
+      objclass="${object.class}" objname="${object.name}" refobjs="${ref.objects}" reffiles="${ref.files}" />
+    
+  </target>
+  
+	
+	<!--
     Rollback to the previous firmware (and filesystem contents!).
   -->
   <target name="firmware-rollback" depends="-init-dir, check-access">

--- a/src/dcm-taskdefs.ant.xml
+++ b/src/dcm-taskdefs.ant.xml
@@ -71,6 +71,74 @@
     
   </macrodef>
   
+  <!--
+    Export the specified object (name and class) in a ZIP format.
+    
+    Required parameters:
+      host - hostname or IP address of DataPower device
+      uid - userid
+      pwd - password
+      local - filename for ZIP file created by this operation
+      objname - target object's name to be exported
+      objclass - target object's class 
+      
+      
+    Optional parameters:
+      port - XML Management Interface port on device (defaults to 5550)
+      ignore-errors - defaults to false
+      refobjs - Include referenced objects? defaults to true
+      reffiles - Include referenced files? defaults to true 
+    
+  -->
+	<macrodef name="exportObject">
+    <attribute name="domain"/>
+    <attribute name="host"/>
+    <attribute name="local"/>
+    <attribute name="port" default="5550"/>
+    <attribute name="uid"/>
+    <attribute name="pwd"/>
+    <attribute name="dumpinput" default="false"/>
+    <attribute name="dumpoutput" default="false"/>
+    <attribute name="capturesoma" default=""/>
+    <attribute name="ignore-errors" default="false"/>
+  	
+    <attribute name="objclass"/>
+    <attribute name="objname" />
+    <attribute name="refobjs"  default="true"/>
+    <attribute name="reffiles" default="true"/>
+  	
+    <sequential>
+      <local name="export_success"/>
+      <local name="export_response"/>
+    	
+      <!-- Export the specified object based on the options given. -->
+      <wdp operation="Export" successprop="export_success" responseprop="export_response" dumpinput="@{dumpinput}" dumpoutput="@{dumpoutput}" capturesoma="@{capturesoma}">
+          <objects xmlns:soma="http://www.datapower.com/schemas/management">
+              <soma:object class="@{objclass}" name="@{objname}" ref-objects="@{refobjs}" ref-files="@{reffiles}"/>
+          </objects>
+          <local>@{local}</local>
+          <hostname>@{host}</hostname>
+          <port>@{port}</port>
+          <uid>@{uid}</uid>
+          <pwd>@{pwd}</pwd>
+          <ignore-errors>@{ignore-errors}</ignore-errors>
+          <domain>@{domain}</domain>
+      </wdp>
+      
+      <if>
+        <equals arg1="${export_success}" arg2="true"/>
+        <then>
+          <echo>Exported object @{objname} into @{local} where</echo>
+          <echo>class=@{objclass} ref-objects=@{refobjs} ref-files=@{reffiles} domain=@{domain} hostname=@{host}.</echo>
+        </then>
+        <else>
+          <echo>Raw response for export: ${export_response}</echo>
+          <fail message="Failed to export object @{objname} of class=@{objclass} from domain @{domain} on @{host}."/>
+        </else>
+      </if>
+        	
+    </sequential>
+  </macrodef>
 
   <!--
     

--- a/src/main/zip/info.xml
+++ b/src/main/zip/info.xml
@@ -124,7 +124,7 @@
   </meta-html>
     
   <!-- Do not change the release-version, the build process injects it. -->
-  <release-version>8</release-version>
+  <release-version>9</release-version>
     
     
   <release-notes>
@@ -138,6 +138,7 @@
     <release-note plugin-version="2"> Fix issue #1 - set ANT_HOME to plugin's version of Ant. </release-note>
     <release-note plugin-version="7"> Expose UploadFromDef, GetObjectStatus, RestartDomain. </release-note>
     <release-note plugin-version="8"> Move xalan to apache-ant/lib, use current version of ant (1.9.7). </release-note>
+    <release-note plugin-version="9"> Export Object </release-note>
     
   </release-notes>
 </pluginInfo>

--- a/src/main/zip/plugin.xml
+++ b/src/main/zip/plugin.xml
@@ -19,7 +19,7 @@
 <plugin xmlns="http://www.urbancode.com/PluginXMLSchema_v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
-    <identifier version="8" id="com.ibm.datapower" name="DataPower"/>
+    <identifier version="9" id="com.ibm.datapower" name="DataPower"/>
     <description>The IBM WebSphere DataPower plugin deploys DataPower services.</description>
     <tag>Infrastructure/WebSphere DataPower</tag>
   </header>
@@ -477,6 +477,69 @@
 
 
 
+  <step-type name="Export Object">
+    <description>Export an object from a domain on a device</description>
+    <properties>
+      <property name="domainName">
+        <property-ui type="textBox" default-value="${p:dpDomainName}" label="Domain name" description="Name of the first domain to backup"/>
+      </property>
+      <property name="objectClass">
+        <property-ui type="textBox" default-value="" label="Object Class" description="Object class e.g. MultiProtocolGateway or WSGateway"/>
+      </property>
+      <property name="objectName">
+        <property-ui type="textBox" default-value="" label="Object Name" description="Object name e.g. name of service"/>
+      </property>
+      <property name="refObjects">
+        <property-ui type="checkBox" default-value="true" label="Include reference objects?" description="Include referenced objects when exporting?"/>
+      </property>
+      <property name="refFiles">
+        <property-ui type="checkBox" default-value="true" label="Include reference files?" description="Include referenced files when exporting?"/>
+      </property>
+      <property name="exportFile">
+        <property-ui type="textBox" default-value="" label="Export file" description="DataPower export file to create/overwrite"/>
+      </property>
+      <property name="hostname">
+        <property-ui type="textBox" default-value="${p:dpHostname}" label="DataPower hostname/IP" description="Hostname or IP address of DataPower appliance" hidden="true"/>
+      </property>
+      <property name="uid">
+        <property-ui type="textBox" default-value="${p:dpUserid}" label="DataPower userid" description="Userid on DataPower appliance" hidden="true"/>
+      </property>
+      <property name="pwd">
+        <property-ui type="secureBox" default-value="${p:dpPassword}" label="DataPower password" description="Password for userid on DataPower appliance" hidden="true"/>
+      </property>
+      <property name="portXMI">
+        <property-ui type="textBox" default-value="${p:dpXMIPort}" label="DataPower XMI port" description="XML Management Interface port on DataPower appliance (usually 5550)" hidden="true"/>
+      </property>
+      <property name="addlProperties">
+        <property-ui type="textBox" default-value="" label="Additional Properties" description="Additional property mappings - antpropname=...[ '~' more definitions ]" hidden="true"/>
+      </property>
+    </properties>
+    <post-processing><![CDATA[
+    if (properties.get("exitCode") != 0) {
+            properties.put(new java.lang.String("Status"), new java.lang.String("Failure"));
+        }
+        else {
+            properties.put("Status", "Success");
+        }
+     ]]></post-processing>
+    <command program="${GROOVY_HOME}/bin/groovy">
+      <arg value="-cp"/>
+      <arg file="classes"/>
+      <arg file="RunDeployDotAnt.groovy"/>
+      <arg file="${PLUGIN_INPUT_PROPS}"/>
+      <arg file="${PLUGIN_OUTPUT_PROPS}"/>
+      <arg value="-Ddomain=@domainName@"/>
+      <arg value="-Dobject.class=@objectClass@"/>
+      <arg value="-Dobject.name=@objectName@"/>
+      <arg value="-Dref.objects=@refObjects@"/>
+      <arg value="-Dref.files=@refFiles@"/>
+      <arg value="-Dexport.file=@exportFile@"/>
+      <arg value="export-object"/>
+    </command>
+  </step-type>
+  
+  
+  
   <step-type name="Host Alias Remove">
     <description>Remove a host alias</description>
     <properties>

--- a/src/main/zip/upgrade.xml
+++ b/src/main/zip/upgrade.xml
@@ -194,4 +194,32 @@
     <migrate-command  name="Upload From Definition"/>
   </migrate>
 
+  <migrate to-version="9">
+    <migrate-command  name="Backup Device"/>
+    <migrate-command  name="Backup Domains"/>
+    <migrate-command  name="Checkpoint Delete"/>
+    <migrate-command  name="Checkpoint Restore"/>
+    <migrate-command  name="Checkpoint Save"/>
+    <migrate-command  name="Create Domain"/>
+    <migrate-command  name="Crypto Identity Credential from Definition"/>
+    <migrate-command  name="Crypto Validation Credential from Definition"/>
+    <migrate-command  name="Delete Domain"/>
+    <migrate-command  name="Export Object"/>
+    <migrate-command  name="Host Alias Remove"/>
+    <migrate-command  name="Host Alias Set"/>
+    <migrate-command  name="Import (Basic)"/>
+    <migrate-command  name="Import (Definition)"/>
+    <migrate-command  name="Import (Deployment Policy Object)"/>
+    <migrate-command  name="Invoke any deploy.ant.xml target"/>
+    <migrate-command  name="Load Balancer Group from Definition"/>
+    <migrate-command  name="Quiesce Domain"/>
+    <migrate-command  name="Restart Domain"/>
+    <migrate-command  name="Restore Backup"/>
+    <migrate-command  name="Save Configuration"/>
+    <migrate-command  name="Set Log Level"/>
+    <migrate-command  name="Unquiesce Domain"/>
+    <migrate-command  name="Upload Directory"/>
+    <migrate-command  name="Upload From Definition"/>
+  </migrate>
+
 </plugin-upgrade>


### PR DESCRIPTION
Hello Administrators,
Please find the code for 'export object' plugin step. This 'feature' was discussed in:
https://developer.ibm.com/answers/questions/267903/datapower-config-plugin-how-to-export-one-service.html

Description about this plugin step:
- it allows user to export an object e.g. service
- referenced files and/or referenced objects are parameters (default to true)

I have also emailed the Contributor License Agreement to ibm-datapower-oss@wwpdl.vnet.ibm.com
cheers
Wen
